### PR TITLE
Don't show the download size when it's under 1mb

### DIFF
--- a/Classes/SubscriptionsTableViewController.m
+++ b/Classes/SubscriptionsTableViewController.m
@@ -186,7 +186,7 @@
         }
         
         unsigned long long megaBytes = [[CacheManager sharedCacheManager] numberOfDownloadedBytes];
-        if (megaBytes == 0LLU) {
+        if (megaBytes < 1000LLU) {
             self.toolbarLabelsViewController.auxiliaryText = nil;
         }
         else {


### PR DESCRIPTION
👋 was having a little walk through of the codebase, I'm a user, so thanks for OSSing it!

I'm not sure how, but I'm seeing a download number on a fresh installation

<img width="621" alt="screen shot 2018-12-12 at 12 54 25 pm" src="https://user-images.githubusercontent.com/49038/49888584-59d59680-fe0d-11e8-92a2-93762482089a.png">

So, I expanded the range at which the text is hidden to be under 1MB

<img width="621" alt="screen shot 2018-12-12 at 12 55 18 pm" src="https://user-images.githubusercontent.com/49038/49888741-c2bd0e80-fe0d-11e8-9b10-82eb36b34a7d.png">
